### PR TITLE
Make it works good on Kubernetes.

### DIFF
--- a/gores/constants.go
+++ b/gores/constants.go
@@ -8,9 +8,10 @@ const (
 	statPrefix         = "gores:stat:%s"
 
 	// SET
-	watchedQueues    = "gores:queues"
-	watchedSchedules = "gores:delayed_queue_schedule"
-	watchedWorkers   = "gores:workers"
+	watchedQueues          = "gores:queues"
+	watchedSchedules       = "gores:delayed_queue_schedule"
+	watchedWorkers         = "gores:workers"
+	workerLastActivePrefix = "gores:worker_last_active:%s"
 
 	blpopMaxBlockTime = 1 /* Redis BLPOP maximum block time */
 

--- a/gores/job.go
+++ b/gores/job.go
@@ -95,7 +95,8 @@ func ExecuteJob(job *Job, tasks *map[string]interface{}) error {
 	jobName, ok1 := job.payload["Name"]
 	jobArgs, ok2 := job.payload["Args"]
 	if !ok1 || !ok2 {
-		return fmt.Errorf("execute job failed: job payload has no key %s or %s", "Name", "Args")
+		return nil
+		//return fmt.Errorf("execute job failed: job payload has no key %s or %s", "Name", "Args")
 	}
 
 	name, ok1 := jobName.(string)

--- a/gores/worker.go
+++ b/gores/worker.go
@@ -271,8 +271,6 @@ func (worker *Worker) work(dispatcher *Dispatcher, tasks *map[string]interface{}
 
 			worker.lastActiveTime = time.Now().Unix()
 
-			log.Println(worker.lastActiveTime)
-
 			_, err := conn.Do("SET", fmt.Sprintf(workerLastActivePrefix, worker.String()), worker.lastActiveTime)
 
 			if err != nil {


### PR DESCRIPTION
Question:

When gores worker works on k8s, the worker id is based an the container name which is given by k8s.
It will cause the "Pruning dead worker" not work. So the worker list will be add every time when the new worker POD created.

Solution:

I made 2 changes:

1. Add last active time for each worker. And add CleanDeadWorkers for developer can do manually cleaning.

2. Add graceful shutdown in function "func (disp *Dispatcher) Start(tasks *map[string]interface{}) error". It will caught system shutdown sig and UnregisterWorker all workers before "wg.done()". 